### PR TITLE
Updated the API URL

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -12,7 +12,7 @@ import Footer from "./components/Footer/Footer"
 function App() {
 
   const client = new ApolloClient({
-    uri: "https://graphql-pokemon.now.sh"
+    uri: "https://graphql-pokemon2.vercel.app/"
   })
 
   return (


### PR DESCRIPTION
The server at the old URL's destination was taken down. The API is now hosted at https://graphql-pokemon2.vercel.app/ so I've updated my app accordingly.